### PR TITLE
Fix problem with no index ex. calling / for info

### DIFF
--- a/lib/newrelic/elasticsearch/operation_resolver.rb
+++ b/lib/newrelic/elasticsearch/operation_resolver.rb
@@ -166,6 +166,7 @@ class NewRelic::ElasticsearchOperationResolver
 
   def index
     index = scope[0]
+    return '' unless index
     index.legalize unless index.start_with?('_')
   end
 


### PR DESCRIPTION
When you try to call `client.info` it is calling elastic search on `localhost:9200/` but then you dont have information about index and you will end up with `.start_with?` on `nil`

so this will ensure that at least you are not throwing error.