### PR TITLE
Ensure `client.info` is recorded correctly

### DIFF
--- a/lib/newrelic/elasticsearch/operation_resolver.rb
+++ b/lib/newrelic/elasticsearch/operation_resolver.rb
@@ -166,6 +166,7 @@ class NewRelic::ElasticsearchOperationResolver
 
   def index
     index = scope[0]
+    return nil unless index
     index.legalize unless index.start_with?('_')
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,2 @@
-require 'newrelic/elasticsearch'
 require 'minitest/unit'
 require 'minitest/autorun'


### PR DESCRIPTION
This fixes #3.

Additionally, add a test for the fix - but in doing so turns out the tests no longer work.  Modify the tests so they accurately describe the running environment.

This will introduce a "backward incompatible" problem in that Elasticsearch traces will no longer be recorded unless `notice_nosql_statements` is set to true.