### PR TITLE
Fix tracing of calls with special characters in elasticsearch urls

### DIFF
--- a/lib/newrelic/elasticsearch/operation_resolver.rb
+++ b/lib/newrelic/elasticsearch/operation_resolver.rb
@@ -1,3 +1,5 @@
+require "cgi"
+
 class NewRelic::ElasticsearchOperationResolver
   module Inflector
     refine String do
@@ -136,7 +138,7 @@ class NewRelic::ElasticsearchOperationResolver
   end
 
   def path_components
-    @path_components ||= path.split('/').reject { |s| s.empty? }
+    @path_components ||= CGI::unescape(path).split('/').reject { |s| s.empty? }
   end
 
   def operands

--- a/test/newrelic/elasticsearch_test.rb
+++ b/test/newrelic/elasticsearch_test.rb
@@ -66,6 +66,11 @@ class NewRelic::ElasticsearchOperationResolverTest < Minitest::Unit::TestCase
     assert_equal(['test','test','_warmer','warm'], resolver.path_components)
   end
 
+  def test_path_components_with_special_characters
+    resolver = NewRelic::ElasticsearchOperationResolver.new('POST', '/test%2A/test/_warmer/warm')
+    assert_equal(['test*','test','_warmer','warm'], resolver.path_components)
+  end
+
   def test_operands
     resolver = NewRelic::ElasticsearchOperationResolver.new('GET', '/test/_alias/test-alias')
     assert_equal(['test-alias'], resolver.operands)


### PR DESCRIPTION
Hello,

I noticed that index names with special characters in them did show up in url-encoded format in newrelic. This patch fixes this problem.

Example: Search queries on the index `example_indexes*` resulting in tracings looking like `Elasticsearch example_indexes%2A Search` in newrelic:
![screenshot from 2018-10-08 11-25-42](https://user-images.githubusercontent.com/34413/46601381-26188080-caed-11e8-843f-9ef23669a499.png)
