### PR TITLE
Make gem compatible with elasticsearch v7

### DIFF
--- a/lib/newrelic/elasticsearch.rb
+++ b/lib/newrelic/elasticsearch.rb
@@ -19,7 +19,7 @@ DependencyDetection.defer do
     NewRelic::Agent::MethodTracer.extend(NewRelic::Agent::MethodTracer)
 
     ::Elasticsearch::Transport::Client.class_eval do
-      def perform_request_with_new_relic(method, path, params={}, body=nil)
+      def perform_request_with_new_relic(method, path, params={}, body=nil, *_args)
         resolver = NewRelic::ElasticsearchOperationResolver.new(method, path)
 
         callback = proc do |result, metric, elapsed|
@@ -31,7 +31,7 @@ DependencyDetection.defer do
         end
 
         NewRelic::Agent::Datastores.wrap('Elasticsearch', resolver.operation_name, resolver.index, callback) do
-          perform_request_without_new_relic(method, path, params, body)
+          perform_request_without_new_relic(method, path, params, body, *_args)
         end
       end
 

--- a/newrelic-elasticsearch.gemspec
+++ b/newrelic-elasticsearch.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.12"
+  spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 4.7.5"
   spec.add_development_dependency "webmock"


### PR DESCRIPTION
In the new version of gem new parameter has been added (https://github.com/elastic/elasticsearch-ruby/blob/master/elasticsearch-transport/lib/elasticsearch/transport/client.rb#L174). Therefore it's failing with error when 5th argument is given: `Exception: ArgumentError: wrong number of arguments (given 5, expected 2..4)`